### PR TITLE
Remove port closed notification

### DIFF
--- a/pkg/mocks/scanner.go
+++ b/pkg/mocks/scanner.go
@@ -47,13 +47,11 @@ func (n *NmapScannerMock) StartScan(ipAddresses []string) error {
 	return args.Error(0)
 }
 
-func (n *NmapScannerMock) DiffScans() (map[string]wrapper.PortMap, map[string]wrapper.PortMap) {
+func (n *NmapScannerMock) DiffScans() (map[string]wrapper.PortMap) {
 	args := n.Called(nil)
 	if args.Get(0) == nil {
-		return nil, nil
-	} else if args.Get(1) == nil {
-		return nil, nil
+		return nil
 	} else {
-		return args.Get(0).(map[string]wrapper.PortMap), args.Get(1).(map[string]wrapper.PortMap)
+		return args.Get(0).(map[string]wrapper.PortMap)
 	}
 }

--- a/pkg/mocks/slack.go
+++ b/pkg/mocks/slack.go
@@ -15,11 +15,3 @@ func (s *SlackInterfaceMock) PrintOpenedPorts(host server.Server, ports []uint16
 	}
 }
 
-func (s *SlackInterfaceMock) PrintClosedPorts(host server.Server, ports []uint16) error {
-	args := s.Called(nil)
-	if args.Get(0) == nil {
-		return args.Error(0)
-	} else {
-		return args.Error(0)
-	}
-}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -113,7 +113,7 @@ func (r *Runner) run(configObject config.BaseConfig) error {
 	}
 
 	log.Debug("Analyzing the result of current scan and previous scan")
-	instancesExposed, instancesRemoved := r.nmapSvc.DiffScans()
+	instancesExposed := r.nmapSvc.DiffScans()
 
 	currentScanSlice, err := r.nmapSvc.CurrentScanResults()
 	if err != nil {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -145,25 +145,6 @@ func (r *Runner) run(configObject config.BaseConfig) error {
 			return fmt.Errorf("Run: Error posting to slack %s", err)
 		}
 	}
-
-	log.Debug("Printing closed ports")
-	for host, portsMap := range instancesRemoved {
-		if len(portsMap) == 0 {
-			continue
-		}
-
-		//TODO: Refactor to remove the map to slice conversion.
-		portsSlice := make([]uint16, 0)
-		for port, _ := range portsMap {
-			if port != 0 {
-				portsSlice = append(portsSlice, port)
-			}
-		}
-
-		err = r.slackSvc.PrintClosedPorts(serversMap[host], portsSlice)
-		if err != nil {
-			return fmt.Errorf("Run: Error posting to slack %s", err)
-		}
-	}
+	
 	return nil
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -42,7 +42,6 @@ func TestRun(t *testing.T) {
 			setup: func() {
 				currentScanSlice := []byte{0x00}
 				instancesExposed := make(map[string]wrapper.PortMap)
-				instancesRemoved := make(map[string]wrapper.PortMap)
 				nmapMock.Reset()
 				awsMock.Reset()
 				gcloudMock.Reset()
@@ -52,7 +51,7 @@ func TestRun(t *testing.T) {
 				awsMock.On("GetFileFromS3", mock.Anything).Return(nil, nil)
 				nmapMock.On("ParsePreviousScan", mock.Anything).Return(nil)
 				nmapMock.On("StartScan", mock.Anything).Return(nil)
-				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed, instancesRemoved)
+				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed)
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
 				awsMock.On("UploadObjectToS3", mock.Anything).Return(nil)
 				slackMock.On("PrintOpenedPorts", mock.Anything).Return(nil)
@@ -129,7 +128,6 @@ func TestRun(t *testing.T) {
 			setup: func() {
 				currentScanSlice := []byte{0x00}
 				instancesExposed := make(map[string]wrapper.PortMap)
-				instancesRemoved := make(map[string]wrapper.PortMap)
 				nmapMock.Reset()
 				awsMock.Reset()
 				gcloudMock.Reset()
@@ -139,7 +137,7 @@ func TestRun(t *testing.T) {
 				awsMock.On("GetFileFromS3", mock.Anything).Return(nil, nil)
 				nmapMock.On("ParsePreviousScan", mock.Anything).Return(nil)
 				nmapMock.On("StartScan", mock.Anything).Return(nil)
-				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed, instancesRemoved)
+				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed)
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, fmt.Errorf("Error"))
 			},
 			shouldError: true,
@@ -149,7 +147,6 @@ func TestRun(t *testing.T) {
 			setup: func() {
 				currentScanSlice := []byte{0x00}
 				instancesExposed := make(map[string]wrapper.PortMap)
-				instancesRemoved := make(map[string]wrapper.PortMap)
 				nmapMock.Reset()
 				awsMock.Reset()
 				gcloudMock.Reset()
@@ -159,7 +156,7 @@ func TestRun(t *testing.T) {
 				awsMock.On("GetFileFromS3", mock.Anything).Return(nil, nil)
 				nmapMock.On("ParsePreviousScan", mock.Anything).Return(nil)
 				nmapMock.On("StartScan", mock.Anything).Return(nil)
-				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed, instancesRemoved)
+				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed)
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
 				awsMock.On("UploadObjectToS3", mock.Anything).Return(fmt.Errorf("Error"))
 			},
@@ -172,7 +169,6 @@ func TestRun(t *testing.T) {
 				instancesExposed := make(map[string]wrapper.PortMap)
 				instancesExposed["1.1.1.1"] = make(wrapper.PortMap)
 				instancesExposed["1.1.1.1"][1] = true
-				instancesRemoved := make(map[string]wrapper.PortMap)
 				nmapMock.Reset()
 				awsMock.Reset()
 				gcloudMock.Reset()
@@ -182,39 +178,14 @@ func TestRun(t *testing.T) {
 				awsMock.On("GetFileFromS3", mock.Anything).Return(nil, nil)
 				nmapMock.On("ParsePreviousScan", mock.Anything).Return(nil)
 				nmapMock.On("StartScan", mock.Anything).Return(nil)
-				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed, instancesRemoved)
+				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed)
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
 				awsMock.On("UploadObjectToS3", mock.Anything).Return(nil)
 				slackMock.On("PrintOpenedPorts", mock.Anything).Return(fmt.Errorf("Error"))
 			},
 			shouldError: true,
 		},
-		{
-			desc: "Error if the closed ports are not able to be posted to slack",
-			setup: func() {
-				currentScanSlice := []byte{0x00}
-				instancesExposed := make(map[string]wrapper.PortMap)
-				instancesExposed["1.1.1.1"] = make(wrapper.PortMap)
-				instancesExposed["1.1.1.1"][1] = true
-				instancesRemoved := make(map[string]wrapper.PortMap)
-				instancesRemoved["2.2.2.2"] = make(wrapper.PortMap)
-				instancesRemoved["2.2.2.2"][1] = true
-				nmapMock.Reset()
-				awsMock.Reset()
-				gcloudMock.Reset()
-				slackMock.Reset()
-				awsMock.On("Instances", mock.Anything).Return(nil)
-				gcloudMock.On("Instances", mock.Anything).Return(nil)
-				awsMock.On("GetFileFromS3", mock.Anything).Return(nil, nil)
-				nmapMock.On("ParsePreviousScan", mock.Anything).Return(nil)
-				nmapMock.On("StartScan", mock.Anything).Return(nil)
-				nmapMock.On("DiffScans", mock.Anything).Return(instancesExposed, instancesRemoved)
-				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
-				awsMock.On("UploadObjectToS3", mock.Anything).Return(nil)
-				slackMock.On("PrintOpenedPorts", mock.Anything).Return(nil)
-			},
-			shouldError: true,
-		},
+	
 	}
 
 	for index, testCase := range testCases {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -56,7 +56,6 @@ func TestRun(t *testing.T) {
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
 				awsMock.On("UploadObjectToS3", mock.Anything).Return(nil)
 				slackMock.On("PrintOpenedPorts", mock.Anything).Return(nil)
-				slackMock.On("PrintClosedPorts", mock.Anything).Return(nil)
 			},
 			shouldError: false,
 		},
@@ -213,7 +212,6 @@ func TestRun(t *testing.T) {
 				nmapMock.On("CurrentScanResults", mock.Anything).Return(currentScanSlice, nil)
 				awsMock.On("UploadObjectToS3", mock.Anything).Return(nil)
 				slackMock.On("PrintOpenedPorts", mock.Anything).Return(nil)
-				slackMock.On("PrintClosedPorts", mock.Anything).Return(fmt.Errorf("Error"))
 			},
 			shouldError: true,
 		},

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -101,7 +101,6 @@ func TestNmapDiffScans(t *testing.T) {
 	instancesFromPreviousScan := make(map[string]wrapper.PortMap)
 
 	newInstancesExposed := make(map[string]wrapper.PortMap)
-	instancesClosed := make(map[string]wrapper.PortMap)
 
 	n := New()
 
@@ -111,12 +110,10 @@ func TestNmapDiffScans(t *testing.T) {
 			setup: func() {
 				instancesFromCurrentScan = make(map[string]wrapper.PortMap)
 				instancesFromPreviousScan = make(map[string]wrapper.PortMap)
-				instancesClosed = make(map[string]wrapper.PortMap)
 				newInstancesExposed = make(map[string]wrapper.PortMap)
 				n.scanParser.currentInstances = instancesFromCurrentScan
 				n.scanParser.previousInstances = instancesFromPreviousScan
 				n.scanParser.newInstancesExposed = newInstancesExposed
-				n.scanParser.instancesRemoved = instancesClosed
 				instancesFromCurrentScan[firstInstanceName] = wrapper.PortMap{firstInstancePort: true}
 				instancesFromCurrentScan[secondInstanceName] = wrapper.PortMap{secondInstancePort: true}
 				instancesFromCurrentScan[thirdInstanceName] = wrapper.PortMap{thirdInstancePort: true}
@@ -132,19 +129,16 @@ func TestNmapDiffScans(t *testing.T) {
 			setup: func() {
 				instancesFromCurrentScan = make(map[string]wrapper.PortMap)
 				instancesFromPreviousScan = make(map[string]wrapper.PortMap)
-				instancesClosed = make(map[string]wrapper.PortMap)
 				newInstancesExposed = make(map[string]wrapper.PortMap)
 				n.scanParser.currentInstances = instancesFromCurrentScan
 				n.scanParser.previousInstances = instancesFromPreviousScan
 				n.scanParser.newInstancesExposed = newInstancesExposed
-				n.scanParser.instancesRemoved = instancesClosed
 				instancesFromPreviousScan[firstInstanceName] = make(wrapper.PortMap)
 				instancesFromCurrentScan[secondInstanceName] = make(wrapper.PortMap)
 				instancesFromPreviousScan[firstInstanceName] = wrapper.PortMap{firstInstancePort: true}
 				instancesFromCurrentScan[secondInstanceName] = wrapper.PortMap{secondInstancePort: true}
 			},
 			assertions: func() {
-				assert.Equal(t, true, wrapper.PortMap(instancesClosed[firstInstanceName])[firstInstancePort])
 				assert.Equal(t, true, wrapper.PortMap(newInstancesExposed[secondInstanceName])[secondInstancePort])
 			},
 		},
@@ -153,12 +147,10 @@ func TestNmapDiffScans(t *testing.T) {
 			setup: func() {
 				instancesFromCurrentScan = make(map[string]wrapper.PortMap)
 				instancesFromPreviousScan = make(map[string]wrapper.PortMap)
-				instancesClosed = make(map[string]wrapper.PortMap)
 				newInstancesExposed = make(map[string]wrapper.PortMap)
 				n.scanParser.currentInstances = instancesFromCurrentScan
 				n.scanParser.previousInstances = instancesFromPreviousScan
 				n.scanParser.newInstancesExposed = newInstancesExposed
-				n.scanParser.instancesRemoved = instancesClosed
 				instancesFromCurrentScan[firstInstanceName] = make(map[uint16]bool)
 				instancesFromCurrentScan[firstInstanceName] = wrapper.PortMap{firstInstancePort: true}
 			},
@@ -171,17 +163,15 @@ func TestNmapDiffScans(t *testing.T) {
 			setup: func() {
 				instancesFromCurrentScan = make(map[string]wrapper.PortMap)
 				instancesFromPreviousScan = make(map[string]wrapper.PortMap)
-				instancesClosed = make(map[string]wrapper.PortMap)
+				instancesFromPreviousScan[firstInstanceName] = make(map[uint16]bool)
+				instancesFromPreviousScan[firstInstanceName] = wrapper.PortMap{firstInstancePort: true}
 				newInstancesExposed = make(map[string]wrapper.PortMap)
 				n.scanParser.currentInstances = instancesFromCurrentScan
 				n.scanParser.previousInstances = instancesFromPreviousScan
 				n.scanParser.newInstancesExposed = newInstancesExposed
-				n.scanParser.instancesRemoved = instancesClosed
-				instancesFromPreviousScan[firstInstanceName] = make(map[uint16]bool)
-				instancesFromPreviousScan[firstInstanceName] = wrapper.PortMap{firstInstancePort: true}
 			},
 			assertions: func() {
-				assert.Equal(t, true, wrapper.PortMap(instancesClosed[firstInstanceName])[firstInstancePort])
+				assert.Equal(t, 0, len(newInstancesExposed))
 			},
 		},
 		{
@@ -189,19 +179,17 @@ func TestNmapDiffScans(t *testing.T) {
 			setup: func() {
 				instancesFromCurrentScan = make(map[string]wrapper.PortMap)
 				instancesFromPreviousScan = make(map[string]wrapper.PortMap)
-				instancesClosed = make(map[string]wrapper.PortMap)
 				newInstancesExposed = make(map[string]wrapper.PortMap)
 				n.scanParser.currentInstances = instancesFromCurrentScan
 				n.scanParser.previousInstances = instancesFromPreviousScan
 				n.scanParser.newInstancesExposed = newInstancesExposed
-				n.scanParser.instancesRemoved = instancesClosed
 			},
 			assertions: func() {
 				assert.Equal(t, 0, len(newInstancesExposed))
-				assert.Equal(t, 0, len(instancesClosed))
 			},
 		},
 	}
+
 
 	for index, testCase := range testCases {
 		log.WithFields(log.Fields{
@@ -212,6 +200,7 @@ func TestNmapDiffScans(t *testing.T) {
 		n.DiffScans()
 		testCase.assertions()
 	}
+
 }
 
 func TestRunNmapScan(t *testing.T) {

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -158,20 +158,5 @@ func (s *slack) PrintOpenedPorts(host server.Server, ports []uint16) error {
 	return nil
 }
 
-//TODO: Refactor usage of server struct to be able to use ports field
-func (s *slack) PrintClosedPorts(host server.Server, ports []uint16) error {
-	if s.slackUrl == "" {
-		return fmt.Errorf("PrintClosedPorts: slackUrl cannot be empty")
-	}
-	for _, port := range ports {
-		text := ":large_red_circle: *Host* `" + host.Name + "` _Closed_ *Port* `" + strconv.FormatUint(uint64(port), 10) + "`"
 
-		attachmentText := "*Address*: " + host.Address + "\n"
-		attachmentText = attachmentText + s.formatLabels(host.Tags)
-		err := s.createBlockSlackPost(text, attachmentText)
-		if err != nil {
-			return fmt.Errorf("PrintClosedPorts: Error posting message to slack %s", err)
-		}
-	}
-	return nil
-}
+

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -16,7 +16,6 @@ import (
 
 type SlackInterface interface {
 	PrintOpenedPorts(host server.Server, ports []uint16) error
-	PrintClosedPorts(host server.Server, ports []uint16) error
 }
 
 type markdownText struct {

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -18,63 +18,6 @@ type slackTestCase struct {
 	shouldError bool
 }
 
-func TestPrintClosedPorts(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
-
-	slackInterface := slack{}
-	slackInterface.rateLimit = &rateLimitedHTTPClient{
-		client:   http.DefaultClient,
-		rlClient: rate.NewLimiter(rate.Every(10*time.Second), 10),
-	}
-
-	serverTag := make(map[string]string)
-	serverTag["tagName"] = "tagValue"
-
-	serverInterface := server.Server{
-		Name:    "Instance1",
-		Address: "1.1.1.1",
-		Tags:    serverTag,
-	}
-
-	testCases := []slackTestCase{
-		{
-			desc: "Able to post to slack",
-			setup: func() *httptest.Server {
-				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-			},
-			shouldError: false,
-		},
-		{
-			desc: "Error posting to slack",
-			setup: func() *httptest.Server {
-				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(500)
-				}))
-			},
-			shouldError: true,
-		},
-	}
-
-	for index, testCase := range testCases {
-		log.WithFields(log.Fields{
-			"desc":        testCase.desc,
-			"shouldError": testCase.shouldError,
-		}).Debug("Starting testCase " + strconv.Itoa(index))
-
-		testServer := testCase.setup()
-		slackInterface.slackUrl = testServer.URL
-
-		err := slackInterface.PrintClosedPorts(serverInterface, []uint16{20, 22})
-
-		testServer.Close()
-
-		if testCase.shouldError {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-	}
-}
 
 func TestPrintOpenedPorts(t *testing.T) {
 	log.SetLevel(log.DebugLevel)

--- a/pkg/wrapper/scanner.go
+++ b/pkg/wrapper/scanner.go
@@ -14,7 +14,7 @@ type NmapSvc interface {
 	CurrentScanResults() ([]byte, error)
 	ParsePreviousScan([]byte) error
 	StartScan(ipAddresses []string) error
-	DiffScans() (map[string]PortMap, map[string]PortMap)
+	DiffScans() (map[string]PortMap)
 }
 
 type PortMap map[uint16]bool

--- a/pkg/wrapper/slack.go
+++ b/pkg/wrapper/slack.go
@@ -4,5 +4,4 @@ import "github.com/Invoca/nmap-diff/pkg/server"
 
 type SlackSvc interface {
 	PrintOpenedPorts(host server.Server, ports []uint16) error
-	PrintClosedPorts(host server.Server, ports []uint16) error
-}
+ }


### PR DESCRIPTION
The closed port notification is redundant. This PR deletes closed port notifications to Slack. 