### PR TITLE
Added logic for checkign gcp nats on instances, will skip hosts without a NAT ip

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -51,7 +51,7 @@ func New(configObject config.BaseConfig) (*awsSvc, error) {
 }
 
 // TODO: Look at removing the a.ec2svc field and get a new service from createEC2Service
-// 
+//
 // The only future danger I see here is that by using a.ec2svc you'll get the regions of the "local account" not the
 // "to be scanned account" and the region list may not be the same. ie If the local account disabled us-west-1 then
 // it wouldn't be returned, and hence instances running in us-west-1 would never be scanned in the

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -72,13 +72,12 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
 				}
 					serversMap[newServer.Address] = newServer
-				} else {
-					continue
-			}
+				} 
 		} else {
 			continue
 		}
 	}
+	return nil
 }
 
 type gCloudWrapper struct {

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -67,10 +67,14 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 				newServer.Tags = make(map[string]string)
 				newServer.Name = instance.Name
 				newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-				for index, key := range instance.Tags.Items {
-					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+				if newServer.Address != nil {
+					for index, key := range instance.Tags.Items {
+						newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+					}
+					serversMap[newServer.Address] = newServer
+				} else {
+					continue
 				}
-				serversMap[newServer.Address] = newServer
 			} else {
 				continue
 			}

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -64,19 +64,20 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 		for _, instance := range instances {
 			if len(instance.NetworkInterfaces) > 0 {
 				if len(instance.NetworkInterfaces[0].AccessConfigs) > 0 {
-				newServer := server.Server{}
-				newServer.Tags = make(map[string]string)
-				newServer.Name = instance.Name
-				newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-				for index, key := range instance.Tags.Items {
-					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
-				}
-				serversMap[newServer.Address] = newServer
-					} else {
+					newServer := server.Server{}
+					newServer.Tags = make(map[string]string)
+					newServer.Name = instance.Name
+					newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+					for index, key := range instance.Tags.Items {
+						newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+					}
+					serversMap[newServer.Address] = newServer
+				} else {
 					continue
 				}
 			} else {
-			continue
+				continue
+			}
 		}
 	}
 	return nil

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -67,7 +67,7 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 				newServer.Tags = make(map[string]string)
 				newServer.Name = instance.Name
 				newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-				if newServer.Address != nil {
+				if len(newServer.Address) > 0 {
 					for index, key := range instance.Tags.Items {
 						newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
 					}

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -72,7 +72,9 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
 				}
 					serversMap[newServer.Address] = newServer
-				} 
+				} else {
+					continue
+			}
 		} else {
 			continue
 		}

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -79,7 +79,6 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 			continue
 		}
 	}
-	return nil
 }
 
 type gCloudWrapper struct {

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -63,21 +63,20 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 
 		for _, instance := range instances {
 			if len(instance.NetworkInterfaces) > 0 {
+				if len(instance.NetworkInterfaces[0].AccessConfigs) > 0 {
 				newServer := server.Server{}
 				newServer.Tags = make(map[string]string)
 				newServer.Name = instance.Name
 				newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-				if len(newServer.Address) > 0 {
-					for index, key := range instance.Tags.Items {
-						newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
-					}
+				for index, key := range instance.Tags.Items {
+					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+				}
 					serversMap[newServer.Address] = newServer
 				} else {
 					continue
-				}
-			} else {
-				continue
 			}
+		} else {
+			continue
 		}
 	}
 	return nil

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -62,7 +62,7 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 		log.Debug(len(instances))
 
 		for _, instance := range instances {
-			if length(instance.NetworkInterfaces) > 0 {
+			if len(instance.NetworkInterfaces) > 0 {
 				newServer := server.Server{}
 				newServer.Tags = make(map[string]string)
 				newServer.Name = instance.Name

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -3,13 +3,14 @@ package gcloud
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/Invoca/nmap-diff/pkg/config"
 	"github.com/Invoca/nmap-diff/pkg/server"
 	"github.com/Invoca/nmap-diff/pkg/wrapper"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
-	"strconv"
 )
 
 type GCloudInterface interface {
@@ -61,14 +62,18 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 		log.Debug(len(instances))
 
 		for _, instance := range instances {
-			newServer := server.Server{}
-			newServer.Tags = make(map[string]string)
-			newServer.Name = instance.Name
-			newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
-			for index, key := range instance.Tags.Items {
-				newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+			if length(instance.NetworkInterfaces) > 0 {
+				newServer := server.Server{}
+				newServer.Tags = make(map[string]string)
+				newServer.Name = instance.Name
+				newServer.Address = instance.NetworkInterfaces[0].AccessConfigs[0].NatIP
+				for index, key := range instance.Tags.Items {
+					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
+				}
+				serversMap[newServer.Address] = newServer
+			} else {
+				continue
 			}
-			serversMap[newServer.Address] = newServer
 		}
 	}
 	return nil

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -72,13 +72,13 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
 				}
 					serversMap[newServer.Address] = newServer
-				} else {
-					continue
-			}
-		} else {
-			continue
+							} else {
+								continue
+							}
+						} else {
+							continue
+				}
 		}
-	}
 	return nil
 }
 

--- a/pkg/gcloud/gcloud.go
+++ b/pkg/gcloud/gcloud.go
@@ -71,14 +71,14 @@ func (g *gCloudSvc) Instances(serversMap map[string]server.Server) error {
 				for index, key := range instance.Tags.Items {
 					newServer.Tags[strconv.FormatInt(int64(index), 10)] = key
 				}
-					serversMap[newServer.Address] = newServer
-							} else {
-								continue
-							}
-						} else {
-							continue
+				serversMap[newServer.Address] = newServer
+					} else {
+					continue
 				}
+			} else {
+			continue
 		}
+	}
 	return nil
 }
 

--- a/pkg/gcloud/gcloud_test.go
+++ b/pkg/gcloud/gcloud_test.go
@@ -80,7 +80,7 @@ func TestGetInstances(t *testing.T) {
 			Name: "Instance 4",
 			NetworkInterfaces: []*compute.NetworkInterface{
 				{
-					nil
+					nil,
 				},
 			},
 			Tags: &compute.Tags{

--- a/pkg/gcloud/gcloud_test.go
+++ b/pkg/gcloud/gcloud_test.go
@@ -80,7 +80,11 @@ func TestGetInstances(t *testing.T) {
 			Name: "Instance 4",
 			NetworkInterfaces: []*compute.NetworkInterface{
 				{
-					nil,
+					AccessConfigs: []*compute.AccessConfig{
+						{
+							NatIP: "0",
+						},
+					},
 				},
 			},
 			Tags: &compute.Tags{

--- a/pkg/gcloud/gcloud_test.go
+++ b/pkg/gcloud/gcloud_test.go
@@ -2,14 +2,15 @@ package gcloud
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/Invoca/nmap-diff/pkg/mocks"
 	"github.com/Invoca/nmap-diff/pkg/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/api/compute/v1"
-	"strconv"
-	"testing"
 )
 
 type getInstancesTestCase struct {
@@ -72,6 +73,17 @@ func TestGetInstances(t *testing.T) {
 			Tags: &compute.Tags{
 				Items: []string{
 					"Tag2",
+				},
+			},
+		},
+		{
+			Name: "Instance 4",
+			NetworkInterfaces: []*compute.NetworkInterface{
+				{},
+			},
+			Tags: &compute.Tags{
+				Items: []string{
+					"Tag3",
 				},
 			},
 		},

--- a/pkg/gcloud/gcloud_test.go
+++ b/pkg/gcloud/gcloud_test.go
@@ -79,7 +79,9 @@ func TestGetInstances(t *testing.T) {
 		{
 			Name: "Instance 4",
 			NetworkInterfaces: []*compute.NetworkInterface{
-				{},
+				{
+					nil
+				},
 			},
 			Tags: &compute.Tags{
 				Items: []string{

--- a/pkg/gcloud/gcloud_test.go
+++ b/pkg/gcloud/gcloud_test.go
@@ -67,6 +67,14 @@ func TestGetInstances(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Instance 3",
+			Tags: &compute.Tags{
+				Items: []string{
+					"Tag2",
+				},
+			},
+		},
 	}
 
 	testCases := []getInstancesTestCase{

--- a/pkg/mocks/scanner.go
+++ b/pkg/mocks/scanner.go
@@ -47,7 +47,7 @@ func (n *NmapScannerMock) StartScan(ipAddresses []string) error {
 	return args.Error(0)
 }
 
-func (n *NmapScannerMock) DiffScans() (map[string]wrapper.PortMap) {
+func (n *NmapScannerMock) DiffScans() map[string]wrapper.PortMap {
 	args := n.Called(nil)
 	if args.Get(0) == nil {
 		return nil

--- a/pkg/mocks/slack.go
+++ b/pkg/mocks/slack.go
@@ -14,4 +14,3 @@ func (s *SlackInterfaceMock) PrintOpenedPorts(host server.Server, ports []uint16
 		return args.Error(0)
 	}
 }
-

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -145,6 +145,6 @@ func (r *Runner) run(configObject config.BaseConfig) error {
 			return fmt.Errorf("Run: Error posting to slack %s", err)
 		}
 	}
-	
+
 	return nil
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -185,7 +185,6 @@ func TestRun(t *testing.T) {
 			},
 			shouldError: true,
 		},
-	
 	}
 
 	for index, testCase := range testCases {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -26,7 +26,7 @@ func newParser(previousInstances map[string]wrapper.PortMap, currentInstances ma
 	return p
 }
 
-func (p *scanParser) ParseScans() (map[string]wrapper.PortMap) {
+func (p *scanParser) ParseScans() map[string]wrapper.PortMap {
 	// Iterate through all instances found in  the current scan.
 	for host, ports := range p.currentInstances {
 		// Check if the instance was found in a previous scan. If that is the case, add all ports exposed on this
@@ -56,8 +56,6 @@ func (p *scanParser) checkPortsAdded(host string) {
 		p.newInstancesExposed[host] = portsAdded
 	}
 }
-
-
 
 type nmapWrapper struct {
 	interfaceName string
@@ -207,7 +205,7 @@ func (n *nmapStruct) StartScan(ipAddresses []string) error {
 // DiffScans takes a map of instances from a past scan and a current one. The function returns instances with ports
 // that are were opened and closed. It does this by comparing the two maps that are passed to the function and iterating
 // through each.
-func (n *nmapStruct) DiffScans() (map[string]wrapper.PortMap) {
+func (n *nmapStruct) DiffScans() map[string]wrapper.PortMap {
 	log.WithFields(log.Fields{
 		"previousInstanceCount": len(n.previousInstances),
 		"currentInstanceCount":  len(n.currentInstances),

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -190,7 +190,6 @@ func TestNmapDiffScans(t *testing.T) {
 		},
 	}
 
-
 	for index, testCase := range testCases {
 		log.WithFields(log.Fields{
 			"desc": testCase.desc,

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -156,6 +156,3 @@ func (s *slack) PrintOpenedPorts(host server.Server, ports []uint16) error {
 	}
 	return nil
 }
-
-
-

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -18,7 +18,6 @@ type slackTestCase struct {
 	shouldError bool
 }
 
-
 func TestPrintOpenedPorts(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 

--- a/pkg/wrapper/scanner.go
+++ b/pkg/wrapper/scanner.go
@@ -14,7 +14,7 @@ type NmapSvc interface {
 	CurrentScanResults() ([]byte, error)
 	ParsePreviousScan([]byte) error
 	StartScan(ipAddresses []string) error
-	DiffScans() (map[string]PortMap)
+	DiffScans() map[string]PortMap
 }
 
 type PortMap map[uint16]bool

--- a/pkg/wrapper/slack.go
+++ b/pkg/wrapper/slack.go
@@ -4,4 +4,4 @@ import "github.com/Invoca/nmap-diff/pkg/server"
 
 type SlackSvc interface {
 	PrintOpenedPorts(host server.Server, ports []uint16) error
- }
+}


### PR DESCRIPTION
This code should change how the Nat IP checking works, it should skip hosts that do not have a public IP attached to the VM instances in GCP